### PR TITLE
update to TibiaData API v4

### DIFF
--- a/compute-items-yesterday.mjs
+++ b/compute-items-yesterday.mjs
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import { prettyCreatureNames } from './creatures.mjs';
 
 const getWorlds = async () => {
-	const response = await fetch('https://api.tibiadata.com/v3/worlds');
+	const response = await fetch('https://api.tibiadata.com/v4/worlds');
 	const data = await response.json();
 	const regularWorlds = data.worlds.regular_worlds;
 	const worldNames = regularWorlds.map((world) => world.name);


### PR DESCRIPTION
TibiaData API v3 is deprecated and will be removed soon.

Link:
https://tibiadata.com/2024/01/tibiadata-api-v3-has-been-deprecated/